### PR TITLE
Bugfix/vov 2815

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -722,10 +722,12 @@
 
 				// adjust controls whenever window sizes (used to be in fullscreen only)
 				t.globalBind('resize', function() {
-
-					// don't resize for fullscreen mode
-					if ( !(t.isFullScreen || (mejs.MediaFeatures.hasTrueNativeFullScreen && document.webkitIsFullScreen)) ) {
-						t.setPlayerSize(t.width, t.height);
+					// don't resize inside a frame/iframe
+					if (window.top == window.self) {
+						// don't resize for fullscreen mode
+						if ( !(t.isFullScreen || (mejs.MediaFeatures.hasTrueNativeFullScreen && document.webkitIsFullScreen)) ) {
+							t.setPlayerSize(t.width, t.height);
+						}
 					}
 
 					// always adjust controls


### PR DESCRIPTION
I’ve found some really weird code while looking into this iPhone resizing bug:

``` ruby
if ( !(t.isFullScreen || (mejs.MediaFeatures.hasTrueNativeFullScreen && document.webkitIsFullScreen)) ) {
  t.setPlayerSize(t.width, t.height);
}
```

Here’s the thing: `t.setPlayerSize(x,y)`, in effect, starts by setting `t.width = x; t.height = y`. And `t` is the same object in both places. So it’s setting `t.width = t.width; t.height = t.height`, which (because it's a percentage value) causes some rounding-error-single-pixel increase, which resizes the iframe, which triggers resize, lather, rinse, repeat.

So I can see no real value in that block at all. However, to avoid edge case/compatibility/cosmetic issues I haven't foreseen, I propose just neutering the block when it detects itself running in a frame, not removing it altogether.
